### PR TITLE
Llama el api de regiones desde los filtros

### DIFF
--- a/src/components/Filtros.vue
+++ b/src/components/Filtros.vue
@@ -220,6 +220,7 @@
 </template>
 
 <script>
+import axios from "axios";
 import Resultados from "../components/Resultados.vue";
 import Twitter from "../components/Twitter.vue";
 import Vue from "vue";
@@ -424,24 +425,22 @@ export default {
     restoreTablesValues() {
       const urlDepto = this.$route.params.departamento;
       const queryParams = this.$route.query;
-      console.log(queryParams, urlDepto, this.regiones)
+      console.log(queryParams, urlDepto, this.regiones);
       if (urlDepto) {
         const newDefault = this.regiones.filter(
           region => region.region == urlDepto
         );
-        console.log(newDefault, this.regiones, urlDepto)
+        console.log(newDefault, this.regiones, urlDepto);
         if (newDefault && newDefault[0].region) {
           this.currentRegion = newDefault[0];
-          this.f1 = queryParams.f1 == true;
-          this.f2 = queryParams.f2 == true;
-          this.f3 = queryParams.f3 == true;
-          this.f4 = queryParams.f4 == true;
-          this.f5 = queryParams.f5 == true;
+          this.f1 = queryParams.f1 === "true";
+          this.f2 = queryParams.f2 === "true";
+          this.f3 = queryParams.f3 === "true";
+          this.f4 = queryParams.f4 === "true";
+          this.f5 = queryParams.f5 === "true";
           this.sendToGA();
           this.reAttachTwitterButton();
         }
-        
-        console.log(this.f1)
       }
     },
     // Mandar la pagina visitada a Google Analytics como un custom event
@@ -458,7 +457,13 @@ export default {
     });
     // TODO: Discutir que tiene mas sentido, elegir un dpto por default o no:
     // Si seleccionamos una region automaticamente, los analytics reportaran esa region mucho mas que las demas
-    this.restoreTablesValues();
+    // LLamada al API para tener las regiones, actualizar el store y luego restaurar la tabla de filtros.
+    // Problema original es que esta funcion se llama antes que el store termine de conseguir la data de los partidos.
+    // TODO: quizas hay manera de remover esta llamada.
+    axios.get("https://api.keines.net/regiones").then(response => {
+      this.$store.commit("SET_REGIONES", response.data);
+      this.restoreTablesValues();
+    });
   }
 };
 </script>

--- a/src/components/GridPartidos.vue
+++ b/src/components/GridPartidos.vue
@@ -4,8 +4,12 @@
       <v-item-group v-model="partidosFavoritos" multiple>
         <v-row>
           <v-col
-          v-for="(partido, i) in partidos"
-          :key="i" cols="4" md="3" sm="2">
+            v-for="(partido, i) in partidos"
+            :key="i"
+            cols="4"
+            md="3"
+            sm="2"
+          >
             <v-item v-slot="{ active, toggle }">
               <v-img
                 :src="require(`../assets/partidos/${partido.Imagen}`)"
@@ -13,21 +17,20 @@
                 class="text-right pa-2"
                 @click="toggle"
               >
-              <v-btn class="selection" icon dark>
-                <v-icon>
-                  {{
-                    active
-                      ? "mdi-checkbox-marked-circle"
-                      : "mdi-checkbox-marked-circle-outline"
-                  }}
-                </v-icon>
-              </v-btn>
+                <v-btn class="selection" icon dark>
+                  <v-icon>
+                    {{
+                      active
+                        ? "mdi-checkbox-marked-circle"
+                        : "mdi-checkbox-marked-circle-outline"
+                    }}
+                  </v-icon>
+                </v-btn>
               </v-img>
             </v-item>
           </v-col>
         </v-row>
       </v-item-group>
-
     </v-row>
   </div>
 </template>
@@ -37,10 +40,10 @@ import slugify from "slugify";
 
 export default {
   name: "GridPartidos",
-  data(){
+  data() {
     return {
       partidosFavoritos: []
-    }
+    };
   },
   created() {
     this.$store.dispatch("getPartidos");

--- a/src/components/Stepper.vue
+++ b/src/components/Stepper.vue
@@ -10,9 +10,7 @@
         <div>
           <grid-presidencial></grid-presidencial>
         </div>
-        <v-btn color="primary" @click="e6 = 2">
-          Seleccionar
-        </v-btn>
+        <v-btn color="primary" @click="e6 = 2"> Seleccionar </v-btn>
       </v-stepper-content>
 
       <v-stepper-step :complete="e6 > 2" step="2">
@@ -22,9 +20,7 @@
 
       <v-stepper-content step="2">
         <filtros></filtros>
-        <v-btn color="primary" @click="e6 = 3">
-          Continue
-        </v-btn>
+        <v-btn color="primary" @click="e6 = 3"> Continue </v-btn>
       </v-stepper-content>
 
       <v-stepper-step :complete="e6 > 3" step="3">
@@ -33,12 +29,8 @@
       </v-stepper-step>
       <v-stepper-content step="3">
         <v-card color="grey lighten-1" class="mb-12" height="200px"></v-card>
-        <v-btn color="primary" @click="e6 = 4">
-          Continue
-        </v-btn>
-        <v-btn text>
-          Cancel
-        </v-btn>
+        <v-btn color="primary" @click="e6 = 4"> Continue </v-btn>
+        <v-btn text> Cancel </v-btn>
       </v-stepper-content>
     </v-stepper>
   </div>

--- a/src/components/StepperCongreso.vue
+++ b/src/components/StepperCongreso.vue
@@ -49,9 +49,11 @@
           ></v-checkbox>
           <v-checkbox
             v-model="f2"
-            :label="`
+            :label="
+              `
             Descartar partidos que votaron por la vacancia (Noviembre 2019)
-            `"
+            `
+            "
           ></v-checkbox>
           <v-checkbox
             v-model="f3"
@@ -59,7 +61,9 @@
           ></v-checkbox>
           <v-checkbox
             v-model="f4"
-            :label="`Descartar listas donde el número 1 no fue electo en democracia interna`"
+            :label="
+              `Descartar listas donde el número 1 no fue electo en democracia interna`
+            "
           ></v-checkbox>
           <v-checkbox
             v-model="f5"
@@ -78,7 +82,6 @@
 </template>
 
 <script>
-
 import GridPartidos from "./GridPartidos.vue";
 
 export default {
@@ -108,7 +111,7 @@ export default {
   },
   methods: {
     filterButtonClicked() {
-      console.log(this.regiones[this.currentRegion])
+      console.log(this.regiones[this.currentRegion]);
       if (this.currentRegion.region) {
         this.$router.push({
           name: "filtros",


### PR DESCRIPTION
**Problema:**
- cuando el app carga directamente en la pagina de /#/filtros (sin pasar por home), las regiones no estan disponibles.

**Fix:**
Creo que debe haber una solucion mas elegante a este problema... pero de momento, se llama directamente al API desde filtros para cerciorarnos que tenemos regiones antes de hacer nada con los filtros del url.